### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/gir_ffi-pango.gemspec
+++ b/gir_ffi-pango.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
+  spec.add_dependency "gir_ffi", "~> 0.17.0"
 
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "pry", "~> 0.14.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
