### PR TITLE
Update RuboCop configuration and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance

--- a/gir_ffi-pango.gemspec
+++ b/gir_ffi-pango.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/end_to_end/context_test.rb
+++ b/test/end_to_end/context_test.rb
@@ -7,6 +7,7 @@ describe Pango::Context do
     it "returns a descendant from Pango::FontMap" do
       ctx = Gdk.pango_context_get
       result = ctx.get_font_map
+
       _(result.class.ancestors).must_include Pango::FontMap
     end
   end

--- a/test/unit/language_test.rb
+++ b/test/unit/language_test.rb
@@ -5,6 +5,7 @@ require File.expand_path("../test_helper.rb", File.dirname(__FILE__))
 describe Pango::Language do
   it "creates an instance with .from_string" do
     lang = Pango::Language.from_string "en"
+
     _(lang).wont_be_nil
     _(lang).must_be_instance_of Pango::Language
   end
@@ -13,6 +14,7 @@ describe Pango::Language do
     it "returns an enumerable of symbols representing scripts" do
       lang = Pango::Language.from_string "ja"
       scripts = lang.get_scripts
+
       _(scripts.to_a).must_equal [:han, :katakana, :hiragana]
     end
 
@@ -20,9 +22,11 @@ describe Pango::Language do
       lang = Pango::Language.from_string "en"
 
       result = lang.get_scripts
+
       _(result.to_a).must_equal [:latin]
 
       result = lang.get_scripts
+
       _(result.to_a).must_equal [:latin]
     end
   end
@@ -31,6 +35,7 @@ describe Pango::Language do
     it "returns an enumerable of symbols representing scripts" do
       lang = Pango::Language.from_string "ja"
       scripts = lang.scripts
+
       _(scripts.to_a).must_equal [:han, :katakana, :hiragana]
     end
 
@@ -38,9 +43,11 @@ describe Pango::Language do
       lang = Pango::Language.from_string "en"
 
       result = lang.scripts
+
       _(result.to_a).must_equal [:latin]
 
       result = lang.scripts
+
       _(result.to_a).must_equal [:latin]
     end
   end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
